### PR TITLE
Removing redundant prefixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@
 exports = module.exports = window.requestAnimationFrame
   || window.webkitRequestAnimationFrame
   || window.mozRequestAnimationFrame
-  || window.oRequestAnimationFrame
-  || window.msRequestAnimationFrame
   || fallback;
 
 /**
@@ -29,8 +27,6 @@ function fallback(fn) {
 var cancel = window.cancelAnimationFrame
   || window.webkitCancelAnimationFrame
   || window.mozCancelAnimationFrame
-  || window.oCancelAnimationFrame
-  || window.msCancelAnimationFrame
   || window.clearTimeout;
 
 exports.cancel = function(id){


### PR DESCRIPTION
According to [caniuse](http://caniuse.com/#search=requestanimationframe), there have never been `ms` and `o` prefixes for requestAnimationFrame.

I'd even go as far as to drop `moz` & `webkit`. They cover only 3% of old browsers which would than just use setTimeout fallback, but except cleaning the code there is no other reason to drop them. Thoughts?
