### PR TITLE
fix for ie11

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Expose `requestAnimationFrame()`.
  */
 
-exports = module.exports = window.requestAnimationFrame
+exports = module.exports = (window.requestAnimationFrame && window.requestAnimationFrame.bind(window))
   || window.webkitRequestAnimationFrame
   || window.mozRequestAnimationFrame
   || fallback;
@@ -24,7 +24,7 @@ function fallback(fn) {
  * Cancel.
  */
 
-var cancel = window.cancelAnimationFrame
+var cancel = (window.cancelAnimationFrame && window.cancelAnimationFrame.bind(window))
   || window.webkitCancelAnimationFrame
   || window.mozCancelAnimationFrame
   || window.clearTimeout;


### PR DESCRIPTION
would like to verify that someone else is running into this but it seems like if you use raf inside another function where `this` is not `window`, you're in trouble

``` js
var raf = require('raf')

(function () {
  raf(function () {
    // error, but raf.call(window, fn) works...
  })
).call({})
```
