### PR TITLE
package: Add license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "component-raf",
   "description": "request animation frame",
   "version": "1.2.0",
+  "license": "MIT",
   "keywords": [
     "animate",
     "requestAnimationFrame",


### PR DESCRIPTION
Adding license metadata to package.json so that tools that reason about licenses will know what to do with this one.
"MIT" is pulled from `Readme.md`.